### PR TITLE
Add new Go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ List of content
 * [libra-grpc-py](https://github.com/egorsmkv/libra-grpc-py) - gRPC client for Libra in Python.
 
 # Go Libraries
-* [libra_example](https://github.com/phlip9/libra_example) - Example Libra Go client SDK.
 * [Libra Golang Client](https://github.com/codemaveric/libra-go) - Go Client for interacting with Libra Blockchain.
+* [Libra SDK for Go](https://github.com/philippgille/libra-sdk-go) - Go SDK for Libra.
+* [libra_example](https://github.com/phlip9/libra_example) - Example Libra Go client SDK.
 
 # Playgrounds
 * [libraide](https://libraide.com/) - Libra Move contract editor.


### PR DESCRIPTION
- Added https://github.com/philippgille/libra-sdk-go to the list of Go libraries
- Also moved https://github.com/phlip9/libra_example to the bottom of the list of Go libraries, because it seems to be only an example that uses gRPC instead of a library on top of that